### PR TITLE
catch internal error and log failed classes

### DIFF
--- a/src/main/java/io/github/hengyunabc/dumpclass/DumpMain.java
+++ b/src/main/java/io/github/hengyunabc/dumpclass/DumpMain.java
@@ -47,7 +47,7 @@ public class DumpMain {
 			throws MalformedURLException, SecurityException, NoSuchMethodException, ClassNotFoundException,
 			IllegalArgumentException, IllegalAccessException, InvocationTargetException, InterruptedException {
 
-		// check if need to reluanch
+		// when sa-jdi not exist in classpath, create a new classloader with sa-jdi in java_home
 		checkRelaunch(args);
 
 		ClassLoader classLoader = DumpMain.class.getClassLoader();
@@ -129,9 +129,11 @@ public class DumpMain {
 			// build a new classloader, a trick.
 			List<URL> urls = new ArrayList<URL>();
 			for (URL url : ((URLClassLoader) DumpMain.class.getClassLoader()).getURLs()) {
+				//add urls in original classloader to the new one
 				urls.add(url);
 			}
 
+			//add sa-jdi to the new classloader
 			urls.add(file.toURI().toURL());
 
 			URLClassLoader classLoader = new URLClassLoader(urls.toArray(new URL[0]),
@@ -143,6 +145,7 @@ public class DumpMain {
 				mainMethod.setAccessible(true);
 			}
 
+			//code is in fact running here
 			new Thread(new Runnable() {
 				@Override
 				public void run() {
@@ -159,6 +162,7 @@ public class DumpMain {
 
 			}).start();
 
+			//sleep util user quit, prevent main method running
 			Thread.currentThread().sleep(Long.MAX_VALUE);
 		}
 	}

--- a/src/main/java/io/github/hengyunabc/dumpclass/DumpWrapperFilter.java
+++ b/src/main/java/io/github/hengyunabc/dumpclass/DumpWrapperFilter.java
@@ -100,6 +100,9 @@ public class DumpWrapperFilter implements ClassFilter {
 			try {
 				ClassWriter cw = new ClassWriter(kls, os);
 				cw.write();
+			} catch (InternalError e) {
+				System.out.println(klassName + " write error");
+				e.printStackTrace();
 			} finally {
 				if (os != null) {
 					os.close();


### PR DESCRIPTION
Some classes got internal error.
```java
java.lang.InternalError
	at sun.jvm.hotspot.tools.jcore.ClassWriter.writeIndex(ClassWriter.java:106)
	at sun.jvm.hotspot.tools.jcore.ClassWriter.writeMethod(ClassWriter.java:550)
	at sun.jvm.hotspot.tools.jcore.ClassWriter.writeMethods(ClassWriter.java:431)
	at sun.jvm.hotspot.tools.jcore.ClassWriter.write(ClassWriter.java:93)
	at io.github.hengyunabc.dumpclass.DumpWrapperFilter.dumpKlass(DumpWrapperFilter.java:102)
	at io.github.hengyunabc.dumpclass.DumpWrapperFilter.canInclude(DumpWrapperFilter.java:33)
	at sun.jvm.hotspot.tools.jcore.ClassDump.dumpKlass(ClassDump.java:138)
	at sun.jvm.hotspot.tools.jcore.ClassDump.access$000(ClassDump.java:38)
	at sun.jvm.hotspot.tools.jcore.ClassDump$1.visit(ClassDump.java:109)
	at sun.jvm.hotspot.memory.Dictionary.classesDo(Dictionary.java:68)
	at sun.jvm.hotspot.memory.SystemDictionary.classesDo(SystemDictionary.java:190)
	at sun.jvm.hotspot.tools.jcore.ClassDump.run(ClassDump.java:105)
	at sun.jvm.hotspot.tools.Tool.startInternal(Tool.java:260)
	at sun.jvm.hotspot.tools.Tool.start(Tool.java:223)
	at sun.jvm.hotspot.tools.Tool.execute(Tool.java:118)
	at sun.jvm.hotspot.tools.jcore.ClassDump.main(ClassDump.java:180)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at io.github.hengyunabc.dumpclass.DumpMain.main(DumpMain.java:99)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at io.github.hengyunabc.dumpclass.DumpMain$2.run(DumpMain.java:151)
```

Not sure the exactly reason, maybe related to jdk version. 

So just catch the exception to avoid the error slow down program, and log failed classes.